### PR TITLE
Add bash in script commands, default GNU

### DIFF
--- a/jeif98/README.md
+++ b/jeif98/README.md
@@ -17,4 +17,4 @@ There are two versions of the code, "original" which is the version of the code 
 Scripts: <br>
 The top-level script for running the "synthetic" experiments is <a href="https://github.com/quenot/opflow/raw/master/jeif98/bat8.sh">bat8.sh</a> </br>
 The top-level script for running the "real" experiments is <a href="https://github.com/quenot/opflow/raw/master/jeif98/treal60.sh">treal60.sh</a> </br>
-These scripts assume the presence of executables compiled with both the GNU and the Intel compilers. If Intel executables are absent, the corresponding lines in the scripts should be commented out.
+These scripts can run executables compiled with both the GNU and the Intel compilers. If Intel executables are available, the corresponding lines in the scripts should be uncommented.

--- a/jeif98/bat8.sh
+++ b/jeif98/bat8.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-table1-2.sh threaded/intel Angle > table1.pi.tex ; table1-2.sh original/linux Angle > table1.og.tex ; table1-2.sh original/intel Angle > table1.oi.tex ; table1-2.sh threaded/linux Angle > table1.pg.tex
-table1-2.sh threaded/intel Value > table2.pi.tex ; table1-2.sh original/linux Value > table2.og.tex ; table1-2.sh original/intel Value > table2.oi.tex ; table1-2.sh threaded/linux Value > table2.pg.tex
+#table1-2.sh threaded/intel Angle > table1.pi.tex;
+ bash table1-2.sh original/linux Angle > table1.og.tex;
+ #table1-2.sh original/intel Angle > table1.oi.tex;
+ bash table1-2.sh threaded/linux Angle > table1.pg.tex
+#table1-2.sh threaded/intel Value > table2.pi.tex;
+ bash table1-2.sh original/linux Value > table2.og.tex;
+ #table1-2.sh original/intel Value > table2.oi.tex;
+ bash table1-2.sh threaded/linux Value > table2.pg.tex

--- a/jeif98/synthetic3.sh
+++ b/jeif98/synthetic3.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo -n '$'
-synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 6" $4
+bash synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 6" $4
 echo -n '$ & $'
-synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 4 -P 2 -N 2 -MF 4 -SUM" $4
+bash synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 4 -P 2 -N 2 -MF 4 -SUM" $4
 echo -n '$ & $'
-synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 4 -P 2 -N 2 -MF 4" $4
+bash synthetic1.sh $1 $2 $3 "-WIN 0.7 -SPW 0.7 -GOA -SMO 4.0 -EPS 3.0 -MB 4 -P 2 -N 2 -MF 4" $4
 echo '$ \\'

--- a/jeif98/table1-2.sh
+++ b/jeif98/table1-2.sh
@@ -1,10 +1,10 @@
-synthetic3.sh $1 cyl10 perfect $2
-synthetic3.sh $1 cyl10 noise05 $2
-synthetic3.sh $1 cyl10 noise10 $2
-synthetic3.sh $1 cyl10 noise20 $2
-synthetic3.sh $1 cyl10 addrm05 $2
-synthetic3.sh $1 cyl10 addrm10 $2
-synthetic3.sh $1 cyl10 addrm20 $2
-synthetic3.sh $1 cyl10 mixed05 $2
-synthetic3.sh $1 cyl10 mixed10 $2
-synthetic3.sh $1 cyl10 mixed20 $2
+bash synthetic3.sh $1 cyl10 perfect $2
+bash synthetic3.sh $1 cyl10 noise05 $2
+bash synthetic3.sh $1 cyl10 noise10 $2
+bash synthetic3.sh $1 cyl10 noise20 $2
+bash synthetic3.sh $1 cyl10 addrm05 $2
+bash synthetic3.sh $1 cyl10 addrm10 $2
+bash synthetic3.sh $1 cyl10 addrm20 $2
+bash synthetic3.sh $1 cyl10 mixed05 $2
+bash synthetic3.sh $1 cyl10 mixed10 $2
+bash synthetic3.sh $1 cyl10 mixed20 $2

--- a/jeif98/treal.sh
+++ b/jeif98/treal.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo $1
-iceg.sh $1 2>&1 >/dev/null | grep real | awk '{print $2}' | sed 's/m/*60+/' | sed 's/s//' | bc -l
+bash iceg.sh $1 2>&1 >/dev/null | grep real | awk '{print $2}' | sed 's/m/*60+/' | sed 's/s//' | bc -l

--- a/jeif98/treal6.sh
+++ b/jeif98/treal6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-treal.sh original/linux
-treal.sh original/intelc
-treal.sh original/intel
-treal.sh threaded/linux
-treal.sh threaded/intelc
-treal.sh threaded/intel
+bash treal.sh original/linux
+#bash treal.sh original/intelc
+#bash treal.sh original/intel
+bash treal.sh threaded/linux
+#bash treal.sh threaded/intelc
+#bash treal.sh threaded/intel

--- a/jeif98/treal60.sh
+++ b/jeif98/treal60.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-treal6.sh > trc0
-treal6.sh > trc1
-treal6.sh > trc2
-treal6.sh > trc3
-treal6.sh > trc4
-treal6.sh > trc5
-treal6.sh > trc6
-treal6.sh > trc7
-treal6.sh > trc8
-treal6.sh > trc9
+bash treal6.sh > trc0
+bash treal6.sh > trc1
+bash treal6.sh > trc2
+bash treal6.sh > trc3
+bash treal6.sh > trc4
+bash treal6.sh > trc5
+bash treal6.sh > trc6
+bash treal6.sh > trc7
+bash treal6.sh > trc8
+bash treal6.sh > trc9
 paste trc[0-9] | grep -v / | awk '{for(i=1;i<=NF;i++){NUM=NUM?NUM+$i:$i};$(NF+1)=NUM;NUM=""} 1' | awk '{printf "%.1f\n", $11/10}'


### PR DESCRIPTION
Ensure scripts run when called from other scripts

Assume Intel compilers may not be available by default, so comment out and allow users to uncomment.

Partially addresses https://github.com/ReScience/submissions/issues/43#issuecomment-695946615